### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To install these tasks into your Team Foundation Server / Azure DevOps Server us
 
 ```
 npm install -g tfx-cli
-tfx build tasks upload --task-zip-path Task.guid-version.zip --service-url https://yourtfs.com/tfs/DefaultCollection/
+tfx build tasks upload --task-zip-path Task.guid-version.zip --service-url https://yourtfs.com/tfs/DefaultCollection
 ```
 
 # Extension


### PR DESCRIPTION
remove trailing `/` from service url

Otherwise I get this error:
```
error: Error: Invalid service url - path is too long. A service URL should include the account/application URL and the collection, e.g. https://fabrikam.visualstudio.com/DefaultCollection or http://tfs-server:8080/tfs/DefaultCollection
```

---

Thank you soo much for this!