### PR TITLE
Remove test keys from Vstest for security compliance

### DIFF
--- a/extensions/visualstudio/fix.ps1
+++ b/extensions/visualstudio/fix.ps1
@@ -1,0 +1,2 @@
+Get-ChildItem -path "_tasks/VSTest-sxs/v*/node_modules/tunnel/test/keys/*.pem" -recurse | Remove-Item
+Get-ChildItem -path "_tasks/VSTest-sxs/v*/node_modules/http-signature/http_signing.md" -recurse | Remove-Item


### PR DESCRIPTION
Eliminate test keys from the Vstest directory to comply with new marketplace security scanning requirements.