### PR TITLE
Enable extensions on latest Azure DevOps Server

### DIFF
--- a/extensions/appcenter/vss-extension.public.json
+++ b/extensions/appcenter/vss-extension.public.json
@@ -2,7 +2,7 @@
   "targets": [
     {
       "id": "Microsoft.TeamFoundation.Server",
-      "version": "[16.0, 20.0)"
+      "version": "[16.0, 21.0)"
     }
   ],
   "public": true,

--- a/extensions/apple-xcode/vss-extension.public.json
+++ b/extensions/apple-xcode/vss-extension.public.json
@@ -2,7 +2,7 @@
   "targets": [
     {
       "id": "Microsoft.TeamFoundation.Server",
-      "version": "[16.0, 20.0)"
+      "version": "[16.0, 21.0)"
     }
   ],
   "public": true

--- a/extensions/generic/vss-extension.public.json
+++ b/extensions/generic/vss-extension.public.json
@@ -2,7 +2,7 @@
   "targets": [
     {
       "id": "Microsoft.TeamFoundation.Server",
-      "version": "[16.0, 19.0)"
+      "version": "[16.0, 21.0)"
     }
   ],
   "public": true


### PR DESCRIPTION
Update the version range for Microsoft.TeamFoundation.Server to support the latest Azure DevOps Server.